### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def make_ezipfile(base_name, base_dir, verbose=0, dry_run=0):
     os.system("zip -A '%s'" % fname)
     of.close()
     os.unlink(ofname)
-    os.chmod(fname,0755)
+    os.chmod(fname,0o755)
     return fname
 
 


### PR DESCRIPTION
"0755" is a invalid syntax/number in python3, use "0o755" which works for
both python2 and python3